### PR TITLE
Add `oracle_enhanced_schema` user to oracle setup 

### DIFF
--- a/puppet/modules/oracle/files/create_rails_users.sql
+++ b/puppet/modules/oracle/files/create_rails_users.sql
@@ -4,6 +4,12 @@ GRANT unlimited tablespace, create session, create table, create sequence,
 create procedure, create trigger, create view, create materialized view,
 create database link, create synonym, create type, ctxapp TO oracle_enhanced;
 
+CREATE USER oracle_enhanced_schema IDENTIFIED BY oracle_enhanced_schema;
+
+GRANT unlimited tablespace, create session, create table, create sequence,
+create procedure, create trigger, create view, create materialized view,
+create database link, create synonym, create type, ctxapp TO oracle_enhanced_schema;
+
 CREATE USER arunit IDENTIFIED BY arunit;
 
 GRANT unlimited tablespace, create session, create table, create sequence,


### PR DESCRIPTION
Thank you for this `rails-dev-box-runs-oracle` project; it makes it much easier to get the specs up and running in the Oracle Enhanced Adapter. This is a small PR I thought you may be interested in; it simply adds a user that the OEA `spec/active_record/connection_adapters/oracle_enhanced_connection_spec.rb ` is expecting should exist.
